### PR TITLE
multiple integrations for imaging data

### DIFF
--- a/dispersed_ramp_simulator.py
+++ b/dispersed_ramp_simulator.py
@@ -160,9 +160,9 @@ class Simulator():
         dispYaml['Output']['grism_source_image'] = False
         dispYaml['Readout']['filter'] = self.pairedFilter
         if self.dispdir.lower() == 'column':
-            dispYaml['Inst']['pupil'] = 'GRISMC'
+            dispYaml['Readout']['pupil'] = 'GRISMC'
         else:
-            dispYaml['Inst']['pupil'] = 'GRISMR'
+            dispYaml['Readout']['pupil'] = 'GRISMR'
             
         #Create an extended target input file using the
         #output dispersed file

--- a/input_params.yaml
+++ b/input_params.yaml
@@ -8,6 +8,7 @@ Readout:
   nframe: 1        #Number of frames per group
   nskip: 0         #Number of skipped frames between groups
   ngroup: 10              #Number of groups in integration
+  nint: 1          #Number of integrations
   namp: 4                               #Number of amplifiers used in readout (4 for full frame, 1 for subarray)
   array_name: NRCA1_FULL    #Name of array (FULL, SUB160, SUB64P, etc) overrides subarray_bounds below
   subarray_bounds: 0, 0, 159, 159          #Coords of subarray corners. (xstart, ystart, xend, yend) Over-ridden by array_name above. Currently not used. Could be used if output saved in raw format

--- a/input_params_moving_target.yaml
+++ b/input_params_moving_target.yaml
@@ -8,6 +8,7 @@ Readout:
   nframe: 1        #Number of frames per group
   nskip: 0         #Number of skipped frames between groups
   ngroup: 4              #Number of groups in integration
+  nint: 1           #Number of integrations
   namp: 4                               #Number of amplifiers used in readout (4 for full frame, 1 for subarray)
   array_name: NRCA1_FULL    #Name of array (FULL, SUB160, SUB64P, etc) overrides subarray_bounds below
   subarray_bounds: 0, 0, 159, 159          #Coords of subarray corners. (xstart, ystart, xend, yend) Over-ridden by array_name above. Currently not used. Could be used if output saved in raw format

--- a/test_disperser_nonsidereal_F250M.yaml
+++ b/test_disperser_nonsidereal_F250M.yaml
@@ -8,6 +8,7 @@ Readout:
   nframe: 1        #Number of frames per group
   nskip: 0         #Number of skipped frames between groups
   ngroup: 5              #Number of groups in integration
+  nint: 1           #Number of integrations
   namp: 4                               #Number of amplifiers used in readout (4 for full frame, 1 for subarray)
   array_name: NRCA1_FULL    #Name of array (FULL, SUB160, SUB64P, etc) overrides subarray_bounds below
   subarray_bounds: 0, 0, 159, 159          #Coords of subarray corners. (xstart, ystart, xend, yend) Over-ridden by array_name above. Currently not used. Could be used if output saved in raw format

--- a/test_disperser_nonsidereal_F300M.yaml
+++ b/test_disperser_nonsidereal_F300M.yaml
@@ -8,6 +8,7 @@ Readout:
   nframe: 1        #Number of frames per group
   nskip: 0         #Number of skipped frames between groups
   ngroup: 5              #Number of groups in integration
+  nint: 1           #Number of integrations
   namp: 4                               #Number of amplifiers used in readout (4 for full frame, 1 for subarray)
   array_name: NRCA1_FULL    #Name of array (FULL, SUB160, SUB64P, etc) overrides subarray_bounds below
   subarray_bounds: 0, 0, 159, 159          #Coords of subarray corners. (xstart, ystart, xend, yend) Over-ridden by array_name above. Currently not used. Could be used if output saved in raw format

--- a/test_disperser_nonsidereal_F335M.yaml
+++ b/test_disperser_nonsidereal_F335M.yaml
@@ -8,6 +8,7 @@ Readout:
   nframe: 1        #Number of frames per group
   nskip: 0         #Number of skipped frames between groups
   ngroup: 5              #Number of groups in integration
+  nint: 1           #Number of integrations
   namp: 4                               #Number of amplifiers used in readout (4 for full frame, 1 for subarray)
   array_name: NRCA1_FULL    #Name of array (FULL, SUB160, SUB64P, etc) overrides subarray_bounds below
   subarray_bounds: 0, 0, 159, 159          #Coords of subarray corners. (xstart, ystart, xend, yend) Over-ridden by array_name above. Currently not used. Could be used if output saved in raw format

--- a/test_disperser_nonsidereal_F410M.yaml
+++ b/test_disperser_nonsidereal_F410M.yaml
@@ -8,6 +8,7 @@ Readout:
   nframe: 1        #Number of frames per group
   nskip: 0         #Number of skipped frames between groups
   ngroup: 5              #Number of groups in integration
+  nint: 1           #Number of integrations
   namp: 4                               #Number of amplifiers used in readout (4 for full frame, 1 for subarray)
   array_name: NRCA1_FULL    #Name of array (FULL, SUB160, SUB64P, etc) overrides subarray_bounds below
   subarray_bounds: 0, 0, 159, 159          #Coords of subarray corners. (xstart, ystart, xend, yend) Over-ridden by array_name above. Currently not used. Could be used if output saved in raw format

--- a/test_disperser_nonsidereal_F480M.yaml
+++ b/test_disperser_nonsidereal_F480M.yaml
@@ -8,6 +8,7 @@ Readout:
   nframe: 1        #Number of frames per group
   nskip: 0         #Number of skipped frames between groups
   ngroup: 5              #Number of groups in integration
+  nint: 1           #Number of integrations
   namp: 4                               #Number of amplifiers used in readout (4 for full frame, 1 for subarray)
   array_name: NRCA1_FULL    #Name of array (FULL, SUB160, SUB64P, etc) overrides subarray_bounds below
   subarray_bounds: 0, 0, 159, 159          #Coords of subarray corners. (xstart, ystart, xend, yend) Over-ridden by array_name above. Currently not used. Could be used if output saved in raw format


### PR DESCRIPTION
Allows the production of exposures with multiple integrations for imaging/WFSS data. Only one integration per exposure allowed for moving targets/non-sidereal tracking.

Also fixed a bug in dispersed_ramp_simulator.py that was leading to incorrect source signal rates. The proper fluxcal value was not being used perviously.