### PR TITLE
Fixed a bug in rotations that affected negative V2 values

### DIFF
--- a/rotations.py
+++ b/rotations.py
@@ -118,9 +118,10 @@ def getv2v3(attitude, ra, dec):
     urd = unit(ra, dec)
     invAtt = np.linalg.inv(attitude)
     uv = np.dot(invAtt,urd)
-    v = radec(uv)
-    v2 = 3600.0*v[0]
-    v3 = 3600.0*v[1]
+    (v2,v3) = radec(uv)
+    if v2 > 180.0: v2 = v2-360.0
+    v2 = 3600.0*v2
+    v3 = 3600.0*v3
     return (v2,v3)
     
 def posangle(attitude, v2,v3):


### PR DESCRIPTION
Previously, negative V2 values within getv2v3, could lead to shifts of (360 degrees - small angular shift) *3600, resulting in V2 values that didn't make any sense.