### PR TITLE
Added warnings that code is no longer supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,18 @@
 # ramp_simulator
+
+WARNING WARNING!!!
+
+THIS CODE IS NO LONGER SUPPORTED!!
+Updated code can now be found in:
+https://github.com/spacetelescope/nircam_simulator
+
+WARNING WARNING!!!
+
+
+
+
+
+
 Code to create high-fidelity simulations of JWST multiaccum integrations.
 
 This code takes an existing real, raw dark current ramp for the instrument being simulated, and adds simulated

--- a/ramp_simulator.py
+++ b/ramp_simulator.py
@@ -59,6 +59,23 @@ class RampSim():
         self.coord_adjust = {'x':1.,'xoffset':0.,'y':1.,'yoffset':0.}
 
     def run(self):
+        #NO LONGER SUPPORTED
+        print("WARNING WARNING!!")
+        print("This code is no longer supported!")
+        print("Updated, easier to use code is located at:")
+        print("https://github.com/spacetelescope/ramp_simulator")
+        print("We recommend you download the updated version")
+        print("of the simulator before running simulations.")
+        print("WARNING WARNING!!")
+        print('')
+        print('')
+        print('')
+        print('')
+        print('')
+        print('')
+        sleep(5)
+
+
         #read in the parameter file
         self.readParameterFile()
 


### PR DESCRIPTION
Now prints to the screen that user should get the updated version of the simulator from the nircam_simulator repo